### PR TITLE
add-analytics

### DIFF
--- a/FPVDevelopment/Components/App.razor
+++ b/FPVDevelopment/Components/App.razor
@@ -17,6 +17,9 @@
     <Routes @rendermode="InteractiveServer"/>
     <script src="_framework/blazor.web.js"></script>
     <script src="_content/MudBlazor/MudBlazor.min.js?v=@(MudBlazor.Metadata.Version)"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@2.9.4/dist/Chart.min.js"></script>
+    <script src="_content/ChartJs.Blazor.Fork/ChartJsBlazorInterop.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.29.1/moment.min.js"></script>
 </body>
 
 </html>

--- a/FPVDevelopment/Components/Layout/NavMenu.razor
+++ b/FPVDevelopment/Components/Layout/NavMenu.razor
@@ -6,7 +6,10 @@
 
 <MudNavMenu>
     <MudNavLink Href="/" Icon="@Icons.Material.Filled.Person" Match="NavLinkMatch.All">Account</MudNavLink>
+    <MudDivider/>
     <MudNavLink Href="/History" Icon="@Icons.Material.Filled.History" Match="NavLinkMatch.Prefix" hidden="@IsNavHidden">History</MudNavLink>
+    <MudNavLink Href="/Analytics" Icon="@Icons.Material.Filled.Analytics" Match="NavLinkMatch.Prefix" hidden="@IsNavHidden">Analytics</MudNavLink>
+    <MudDivider/>
     <MudNavLink Href="/AddCompletedRun" Icon="@Icons.Material.Filled.Add" Match="NavLinkMatch.Prefix" hidden="@IsNavHidden">Add Completed Run</MudNavLink>
     <MudNavLink Href="/AddMap" Icon="@Icons.Material.Filled.Add" Match="NavLinkMatch.Prefix" hidden="@IsNavHidden">Add Map</MudNavLink>
     <MudNavLink Href="/AddCourse" Icon="@Icons.Material.Filled.Add" Match="NavLinkMatch.Prefix" hidden="@IsNavHidden">Add Course</MudNavLink>

--- a/FPVDevelopment/Components/Pages/AddMap.razor
+++ b/FPVDevelopment/Components/Pages/AddMap.razor
@@ -1,7 +1,5 @@
 ﻿@page "/AddMap"
-@using FPVDevelopment.Components.Services
 @using FPVDevelopment.Components.Data.Models
-@using static FPVDevelopment.Components.Globals.Enums
 @inject MapService MapService;
 @inject ISnackbar Snackbar
 @rendermode InteractiveServer

--- a/FPVDevelopment/Components/Pages/Analytics.razor
+++ b/FPVDevelopment/Components/Pages/Analytics.razor
@@ -2,29 +2,42 @@
 @inject CompletedRunService CompletedRunService
 @inject CurrentUser CurrentUser
 
-<h3>Progression Over Time</h3>
 @if (_configByDate != null)
 {
-    <div style="max-width:900px; margin:auto;">
-        <Chart Config="_configByDate" />
-    </div>
+    <MudCard Style="width:100%; margin-bottom:20px;">
+        <MudCardHeader>
+            <MudText Typo="Typo.h6">Progression Over Time</MudText>
+        </MudCardHeader>
+        <MudCardContent>
+            <div style="width:100%;">
+                <Chart Config="_configByDate"/>
+            </div>
+        </MudCardContent>
+    </MudCard>
 }
 else
 {
     <p>No data available.</p>
 }
 
-<h3>Progression by Attempt</h3>
 @if (_configByAttempt != null)
 {
-    <div style="max-width:900px; margin:auto;">
-        <Chart Config="_configByAttempt" />
-    </div>
+    <MudCard Style="width:100%; margin-bottom:20px;">
+        <MudCardHeader>
+            <MudText Typo="Typo.h6">Progression by Attempt</MudText>
+        </MudCardHeader>
+        <MudCardContent>
+            <div style="width:100%;">
+                <Chart Config="_configByAttempt"/>
+            </div>
+        </MudCardContent>
+    </MudCard>
 }
 else
 {
     <p>No data available.</p>
 }
+
 
 @code {
     private LineConfig _configByDate;
@@ -75,7 +88,6 @@ else
                 .OrderBy(r => r.Date)
                 .ToList();
 
-            // Start with the first value if it exists, otherwise 0
             double lastValue = runs.FirstOrDefault()?.Time?.TotalSeconds ?? 0;
 
             var data = new List<double>();
@@ -85,7 +97,6 @@ else
                 if (run != null && run.Time.HasValue)
                     lastValue = run.Time.Value.TotalSeconds;
 
-                // Add the last known value, even if no run exists for this date
                 data.Add(lastValue);
             }
 
@@ -100,9 +111,7 @@ else
             colorIndex++;
         }
 
-
         // -------- Progression by Attempt --------
-        var attempts = _completedRuns.Select((r, i) => i + 1).ToList();
         int maxAttempts = _completedRuns
             .GroupBy(r => r.Course)
             .Max(g => g.Count());

--- a/FPVDevelopment/Components/Pages/Analytics.razor
+++ b/FPVDevelopment/Components/Pages/Analytics.razor
@@ -1,5 +1,123 @@
-<h3>Analytics</h3>
+@page "/Analytics"
+@inject CompletedRunService CompletedRunService
+@inject CurrentUser CurrentUser
+
+<h3>Progression Over Time</h3>
+@if (_configByDate != null)
+{
+    <Chart Config="_configByDate" Style="max-width:900px; margin:auto;" />
+}
+else
+{
+    <p>No data available.</p>
+}
+
+<h3>Progression by Attempt</h3>
+@if (_configByAttempt != null)<h3>Progression Over Time</h3>
+@if (_configByDate != null)
+{
+    <div style="max-width:900px; margin:auto;">
+        <Chart Config="_configByDate" />
+    </div>
+}
+else
+{
+    <p>No data available.</p>
+}
+
+<h3>Progression by Attempt</h3>
+@if (_configByAttempt != null)
+{
+    <div style="max-width:900px; margin:auto;">
+        <Chart Config="_configByAttempt" />
+    </div>
+}
+else
+{
+    <p>No data available.</p>
+}
+}
 
 @code {
-    
+    private LineConfig _configByDate;
+    private LineConfig _configByAttempt;
+
+    private IList<CompletedRun> _completedRuns = new List<CompletedRun>();
+    private readonly string[] _colors = new[] { "#e6194b", "#3cb44b", "#ffe119", "#4363d8" };
+
+    protected override async Task OnInitializedAsync()
+    {
+        _completedRuns = (await CompletedRunService.GetCompletedRuns(CurrentUser.User))?.ToList() ?? new List<CompletedRun>();
+        BuildCharts();
+    }
+
+    private void BuildCharts()
+    {
+        if (!_completedRuns.Any())
+        {
+            _configByDate = null;
+            _configByAttempt = null;
+            return;
+        }
+
+        var courses = _completedRuns.Select(r => r.CourseID).Distinct().ToList();
+
+        // -------- Progression Over Time --------
+        var dates = _completedRuns.Select(r => r.Date.Date).Distinct().OrderBy(d => d).ToList();
+        var dateLabels = dates.Select(d => d.ToString("dd MMM yyyy")).ToList();
+
+        _configByDate = new LineConfig
+        {
+            Options = new LineOptions { Responsive = true }
+        };
+
+        foreach (var label in dateLabels)
+            _configByDate.Data.Labels.Add(label);
+
+        int colorIndex = 0;
+        foreach (var courseId in courses)
+        {
+            var runs = _completedRuns.Where(r => r.CourseID == courseId).ToList();
+            var data = dates.Select(d => runs.FirstOrDefault(r => r.Date.Date == d)?.Time?.TotalSeconds ?? 0).ToList();
+
+            var dataset = new LineDataset<double>(data)
+            {
+                Label = $"Course {courseId}",
+                BorderColor = _colors[colorIndex % _colors.Length],
+                Fill = false
+            };
+
+            _configByDate.Data.Datasets.Add(dataset);
+            colorIndex++;
+        }
+
+        // -------- Progression by Attempt --------
+        var attempts = _completedRuns.Select((r, i) => i + 1).ToList();
+        var attemptLabels = attempts.Select(a => $"Attempt {a}").ToList();
+
+        _configByAttempt = new LineConfig
+        {
+            Options = new LineOptions { Responsive = true }
+        };
+
+        foreach (var label in attemptLabels)
+            _configByAttempt.Data.Labels.Add(label);
+
+        colorIndex = 0;
+        foreach (var courseId in courses)
+        {
+            var runs = _completedRuns.Where(r => r.CourseID == courseId).OrderBy(r => r.Date).ToList();
+            var data = runs.Select(r => r.Time?.TotalSeconds ?? 0).ToList();
+
+            var dataset = new LineDataset<double>(data)
+            {
+                Label = $"Course {courseId}",
+                BorderColor = _colors[colorIndex % _colors.Length],
+                Fill = false
+            };
+
+            _configByAttempt.Data.Datasets.Add(dataset);
+            colorIndex++;
+        }
+    }
 }

--- a/FPVDevelopment/Components/Pages/Analytics.razor
+++ b/FPVDevelopment/Components/Pages/Analytics.razor
@@ -1,0 +1,5 @@
+<h3>Analytics</h3>
+
+@code {
+    
+}

--- a/FPVDevelopment/Components/Pages/Analytics.razor
+++ b/FPVDevelopment/Components/Pages/Analytics.razor
@@ -5,17 +5,6 @@
 <h3>Progression Over Time</h3>
 @if (_configByDate != null)
 {
-    <Chart Config="_configByDate" Style="max-width:900px; margin:auto;" />
-}
-else
-{
-    <p>No data available.</p>
-}
-
-<h3>Progression by Attempt</h3>
-@if (_configByAttempt != null)<h3>Progression Over Time</h3>
-@if (_configByDate != null)
-{
     <div style="max-width:900px; margin:auto;">
         <Chart Config="_configByDate" />
     </div>
@@ -36,14 +25,18 @@ else
 {
     <p>No data available.</p>
 }
-}
 
 @code {
     private LineConfig _configByDate;
     private LineConfig _configByAttempt;
 
     private IList<CompletedRun> _completedRuns = new List<CompletedRun>();
-    private readonly string[] _colors = new[] { "#e6194b", "#3cb44b", "#ffe119", "#4363d8" };
+    private readonly string[] _colors = new[] { 
+        "#e6194b", "#3cb44b", "#ffe119", "#4363d8", "#f58231", 
+        "#911eb4", "#46f0f0", "#f032e6", "#bcf60c", "#fabebe", 
+        "#008080", "#e6beff", "#9a6324", "#fffac8", "#800000", 
+        "#aaffc3", "#808000", "#ffd8b1", "#000075", "#808080" 
+    };
 
     protected override async Task OnInitializedAsync()
     {
@@ -60,7 +53,7 @@ else
             return;
         }
 
-        var courses = _completedRuns.Select(r => r.CourseID).Distinct().ToList();
+        List<Course> courses = _completedRuns.Select(r => r.Course).Distinct().ToList();
 
         // -------- Progression Over Time --------
         var dates = _completedRuns.Select(r => r.Date.Date).Distinct().OrderBy(d => d).ToList();
@@ -75,14 +68,30 @@ else
             _configByDate.Data.Labels.Add(label);
 
         int colorIndex = 0;
-        foreach (var courseId in courses)
+        foreach (var course in courses)
         {
-            var runs = _completedRuns.Where(r => r.CourseID == courseId).ToList();
-            var data = dates.Select(d => runs.FirstOrDefault(r => r.Date.Date == d)?.Time?.TotalSeconds ?? 0).ToList();
+            var runs = _completedRuns
+                .Where(r => r.Course == course)
+                .OrderBy(r => r.Date)
+                .ToList();
+
+            // Start with the first value if it exists, otherwise 0
+            double lastValue = runs.FirstOrDefault()?.Time?.TotalSeconds ?? 0;
+
+            var data = new List<double>();
+            foreach (var date in dates)
+            {
+                var run = runs.FirstOrDefault(r => r.Date.Date == date);
+                if (run != null && run.Time.HasValue)
+                    lastValue = run.Time.Value.TotalSeconds;
+
+                // Add the last known value, even if no run exists for this date
+                data.Add(lastValue);
+            }
 
             var dataset = new LineDataset<double>(data)
             {
-                Label = $"Course {courseId}",
+                Label = course.Name,
                 BorderColor = _colors[colorIndex % _colors.Length],
                 Fill = false
             };
@@ -91,9 +100,15 @@ else
             colorIndex++;
         }
 
+
         // -------- Progression by Attempt --------
         var attempts = _completedRuns.Select((r, i) => i + 1).ToList();
-        var attemptLabels = attempts.Select(a => $"Attempt {a}").ToList();
+        int maxAttempts = _completedRuns
+            .GroupBy(r => r.Course)
+            .Max(g => g.Count());
+        var attemptLabels = Enumerable.Range(1, maxAttempts)
+            .Select(a => $"Attempt {a}")
+            .ToList();
 
         _configByAttempt = new LineConfig
         {
@@ -104,14 +119,14 @@ else
             _configByAttempt.Data.Labels.Add(label);
 
         colorIndex = 0;
-        foreach (var courseId in courses)
+        foreach (var course in courses)
         {
-            var runs = _completedRuns.Where(r => r.CourseID == courseId).OrderBy(r => r.Date).ToList();
+            var runs = _completedRuns.Where(r => r.Course == course).OrderBy(r => r.Date).ToList();
             var data = runs.Select(r => r.Time?.TotalSeconds ?? 0).ToList();
 
             var dataset = new LineDataset<double>(data)
             {
-                Label = $"Course {courseId}",
+                Label = course.Name,
                 BorderColor = _colors[colorIndex % _colors.Length],
                 Fill = false
             };

--- a/FPVDevelopment/Components/Pages/Analytics.razor
+++ b/FPVDevelopment/Components/Pages/Analytics.razor
@@ -74,7 +74,24 @@ else
 
         _configByDate = new LineConfig
         {
-            Options = new LineOptions { Responsive = true }
+            Options = new LineOptions
+            {
+                Responsive = true,
+                Scales = new Scales
+                {
+                    YAxes = new List<CartesianAxis>
+                    {
+                        new LinearCartesianAxis
+                        {
+                            ScaleLabel = new ScaleLabel
+                            {
+                                Display = true,
+                                LabelString = "Time (seconds)"
+                            }
+                        }
+                    }
+                }
+            }
         };
 
         foreach (var label in dateLabels)
@@ -121,7 +138,24 @@ else
 
         _configByAttempt = new LineConfig
         {
-            Options = new LineOptions { Responsive = true }
+            Options = new LineOptions
+            {
+                Responsive = true,
+                Scales = new Scales
+                {
+                    YAxes = new List<CartesianAxis>
+                    {
+                        new LinearCartesianAxis
+                        {
+                            ScaleLabel = new ScaleLabel
+                            {
+                                Display = true,
+                                LabelString = "Time (seconds)"
+                            }
+                        }
+                    }
+                }
+            }
         };
 
         foreach (var label in attemptLabels)

--- a/FPVDevelopment/Components/Pages/Analytics.razor.css
+++ b/FPVDevelopment/Components/Pages/Analytics.razor.css
@@ -1,0 +1,7 @@
+.sticky-filter-panel {
+    position: sticky;
+    top: 0;
+    z-index: 1100;
+    padding: 0.5rem;
+    border-bottom: 1px solid #e0e0e0;
+}

--- a/FPVDevelopment/Components/Pages/History.razor
+++ b/FPVDevelopment/Components/Pages/History.razor
@@ -167,7 +167,7 @@
 
     protected override async Task OnInitializedAsync()
     {
-        _mapList = await  MapService.GetMaps();
+        _mapList = await MapService.GetMaps();
         _completedRunList = await CompletedRunService.GetCompletedRuns(CurrentUser.User);
         CurrentUser.CurrentUserChangedEvent += OnCurrentUserChanged;
         

--- a/FPVDevelopment/Components/Pages/Home.razor
+++ b/FPVDevelopment/Components/Pages/Home.razor
@@ -1,5 +1,4 @@
 ﻿@page "/"
-@using FPVDevelopment.Components.Data.Classes
 @inject UserService UserService
 @inject CurrentUser CurrentUser
 @inject ISnackbar Snackbar

--- a/FPVDevelopment/Components/Services/CompletedRunService.cs
+++ b/FPVDevelopment/Components/Services/CompletedRunService.cs
@@ -13,7 +13,7 @@ namespace FPVDevelopment.Components.Services
             _dbContextFactory = dbContextFactory;
         }
 
-        public async Task<bool> AddCompletedRun(CompletedRun completedRun, User user)
+        public async Task<bool> AddCompletedRun(CompletedRun? completedRun, User? user)
         {
             if (completedRun is null)
                 throw new ArgumentNullException(nameof(completedRun));

--- a/FPVDevelopment/Components/Services/CourseService.cs
+++ b/FPVDevelopment/Components/Services/CourseService.cs
@@ -34,12 +34,21 @@ public class CourseService
         }
     }
 
-    public async Task<IList<Course>> GetCourses()
+    public async Task<IList<Course>> GetCourses(User? user = null)
     {
-        using (FPVDbContext context = await _dbContextFactory.CreateDbContextAsync())
+        using var context = await _dbContextFactory.CreateDbContextAsync();
+
+        if (user is null)
         {
             return await context.Courses
+                .Include(c => c.Map) // optional if you need map info
                 .ToListAsync();
         }
+
+        return await context.Courses
+            .Where(c => c.CompletedRuns.Any(r => r.UserID == user.ID))
+            .Include(c => c.Map)
+            .ToListAsync();
     }
+
 }

--- a/FPVDevelopment/Components/Services/MapService.cs
+++ b/FPVDevelopment/Components/Services/MapService.cs
@@ -34,14 +34,22 @@ namespace FPVDevelopment.Components.Services
             }
         }
 
-        public async Task<IList<Map>> GetMaps()
+        public async Task<IList<Map>> GetMaps(User? user = null)
         {
-            using (FPVDbContext context = await _dbContextFactory.CreateDbContextAsync())
+            using var context = await _dbContextFactory.CreateDbContextAsync();
+
+            if (user is null)
             {
                 return await context.Maps
                     .Include(m => m.Courses)
                     .ToListAsync();
             }
+
+            return await context.Maps
+                .Where(m => m.Courses
+                    .Any(c => c.CompletedRuns.Any(r => r.UserID == user.ID)))
+                .Include(m => m.Courses) // include courses for checkbox display
+                .ToListAsync();
         }
     }
 }

--- a/FPVDevelopment/Components/_Imports.razor
+++ b/FPVDevelopment/Components/_Imports.razor
@@ -10,3 +10,15 @@
 @using FPVDevelopment.Components
 @using Services
 @using MudBlazor
+@using FPVDevelopment.Components.Data.Models
+@using FPVDevelopment.Components.Data.Classes
+@using ChartJs.Blazor;
+@using ChartJs.Blazor.Common
+@using ChartJs.Blazor.Common.Axes
+@using ChartJs.Blazor.Common.Axes.Ticks
+@using ChartJs.Blazor.Common.Enums
+@using ChartJs.Blazor.Common.Handlers
+@using ChartJs.Blazor.Common.Time
+@using ChartJs.Blazor.Util
+@using ChartJs.Blazor.Interop
+@using ChartJs.Blazor.LineChart

--- a/FPVDevelopment/FPVDevelopment.csproj
+++ b/FPVDevelopment/FPVDevelopment.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="ChartJs.Blazor.Fork" Version="2.0.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.8">


### PR DESCRIPTION
Adds analytics page, this is where users can get a visual representation of their data to make more sense than just reading through their history.

Currently its displaying best run progression over time and over attempt counts with more to be added in future.

I was hoping to use mudblazor graphs for this but it was very limited in what it could do, I have chosen to go with ChartJS.Blazor.Fork, however there are still many limitations I am facing, such as currently struggling to format the Y axis to be minutes:seconds but these arent part of the initial requirements to get this page to a minimal viable product